### PR TITLE
chore: drop Laravel 11 and require PHP 8.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # You can add more PHP versions here if you'd like
-        php: [ '8.3' ]
+        php: [ '8.4' ]
 
     steps:
       - name: Check out code
@@ -24,7 +24,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php }}
           coverage: xdebug
 
       - name: Install composer dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `aesircloud/laravel-actions` will be documented in this f
 
 ---
 
+## 1.1.0 - 2025-08-26
+- Drop Laravel 11 support and require PHP 8.4.
+
 ## 1.0.1 - 2025-02-28
 - **Refactor**: Refactor the `Action` class to remove variadic abstract handle function.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A simple actions package for Laravel.
 
+> **Requirements:** PHP 8.4+ and Laravel 12.
+
 ---
 
 <p align="center">

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     }
   ],
   "require": {
-    "php": "^8.3",
-    "illuminate/support": "^11.0|^12.0",
-    "illuminate/console": "^11.0|^12.0",
-    "laravel/framework": "^11.0|^12.0"
+    "php": "^8.4",
+    "illuminate/support": "^12.0",
+    "illuminate/console": "^12.0",
+    "laravel/framework": "^12.0"
   },
   "homepage": "https://github.com/AesirCloud/laravel-actions",
   "autoload": {
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "pestphp/pest": "^3.7",
-    "orchestra/testbench": "^10.0",
+    "orchestra/testbench": "^11.0",
     "pestphp/pest-plugin-laravel": "^3.1"
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "pestphp/pest": "^3.7",
-    "orchestra/testbench": "^11.0@dev",
+    "orchestra/testbench": "^10.6",
     "pestphp/pest-plugin-laravel": "^3.1"
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "pestphp/pest": "^3.7",
-    "orchestra/testbench": "^11.0",
+    "orchestra/testbench": "^11.0@dev",
     "pestphp/pest-plugin-laravel": "^3.1"
   },
   "config": {


### PR DESCRIPTION
## Summary
- require PHP 8.4 and restrict support to Laravel 12
- document new requirements and note them in the changelog
- update CI to run on PHP 8.4

## Testing
- `composer update` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adda8e2b68832cb31f123b47608915