### PR TITLE
Refine action dispatching and command scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `aesircloud/laravel-actions` will be documented in this f
 - Improve default `asController` to throw when `handle` requires parameters.
 - Inject `Filesystem` into `MakeActionCommand`.
 - Align stub publish tag with README and update scaffold command references.
+- Queueing an action without parameters now dispatches the action instance instead of a closure.
 
 ## 1.1.0 - 2025-08-26
 - Drop Laravel 11 support and require PHP 8.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `aesircloud/laravel-actions` will be documented in this f
 
 ---
 
+## 1.1.1 - 2025-09-06
+- Simplify `Action::run` and `dispatch` to avoid passing arguments to the constructor.
+- Improve default `asController` to throw when `handle` requires parameters.
+- Inject `Filesystem` into `MakeActionCommand`.
+- Align stub publish tag with README and update scaffold command references.
+
 ## 1.1.0 - 2025-08-26
 - Drop Laravel 11 support and require PHP 8.4.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ php artisan vendor:publish --tag=actions-stubs
 To scaffold a new action, run the following command:
 
 ```php
-php artisan handle:action {ActionName}
+php artisan make:action {ActionName}
 ```
 
 This will create a new action class in the `app/Actions` directory.
@@ -61,7 +61,7 @@ This will create a new action class in the `app/Actions` directory.
 ### Basic Example
 
 ```php
-php artisan handle:action CreateUser
+php artisan make:action CreateUser
 ```
 
 Creates an action file under `app/Actions/CreateUser.php`.

--- a/src/Action.php
+++ b/src/Action.php
@@ -22,9 +22,9 @@ abstract class Action implements ShouldQueue
      */
     public static function run(mixed ...$arguments): mixed
     {
-        $action = new static(...$arguments);
+        $action = new static();
 
-        return call_user_func_array([$action, 'handle'], $arguments);
+        return $action->handle(...$arguments);
     }
 
     /**
@@ -35,8 +35,9 @@ abstract class Action implements ShouldQueue
      */
     public static function dispatch(mixed ...$arguments): PendingDispatch
     {
-        // Similarly, pass arguments into constructor
-        return (new static(...$arguments))->queue();
+        return dispatch(function () use ($arguments) {
+            return (new static())->handle(...$arguments);
+        });
     }
 
     /**
@@ -63,8 +64,11 @@ abstract class Action implements ShouldQueue
      */
     public function asController(Request $request): mixed
     {
-        // e.g., $data = $request->validate(...);
-        // return $this->handle($data);
+        $method = new \ReflectionMethod($this, 'handle');
+
+        if ($method->getNumberOfRequiredParameters() > 0) {
+            throw new \BadMethodCallException(static::class.'::handle requires parameters. Override asController() to provide them.');
+        }
 
         return $this->handle();
     }

--- a/src/Action.php
+++ b/src/Action.php
@@ -35,6 +35,10 @@ abstract class Action implements ShouldQueue
      */
     public static function dispatch(mixed ...$arguments): PendingDispatch
     {
+        if ($arguments === []) {
+            return dispatch(new static());
+        }
+
         return dispatch(function () use ($arguments) {
             return (new static())->handle(...$arguments);
         });

--- a/src/Commands/MakeActionCommand.php
+++ b/src/Commands/MakeActionCommand.php
@@ -17,10 +17,10 @@ class MakeActionCommand extends Command
     protected string $defaultNamespace = 'App\\Actions';
     protected Filesystem $files;
 
-    public function __construct()
+    public function __construct(Filesystem $files)
     {
         parent::__construct();
-        $this->files = new Filesystem;
+        $this->files = $files;
     }
 
     public function handle(): int

--- a/src/Providers/ActionsServiceProvider.php
+++ b/src/Providers/ActionsServiceProvider.php
@@ -21,7 +21,7 @@ class ActionsServiceProvider extends ServiceProvider
             // Publish stubs (optional)
             $this->publishes([
                 __DIR__ . '/../stubs/action.stub' => base_path('stubs/action.stub'),
-            ], 'laravel-actions-stubs');
+            ], 'actions-stubs');
         }
     }
 


### PR DESCRIPTION
## Summary
- simplify Action::run and dispatch to avoid constructor argument duplication
- add parameter check in Action::asController
- inject Filesystem into MakeActionCommand and fix stub publish tag
- update scaffold command references and changelog

## Testing
- `composer install` *(fails: curl error 56 – CONNECT tunnel failed, response 403)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc52f74390832c87e0dd8d332135fb